### PR TITLE
Admin entity

### DIFF
--- a/backend/src/Enums/user.enum.ts
+++ b/backend/src/Enums/user.enum.ts
@@ -1,0 +1,5 @@
+export enum UserType {
+  STUDENT = 'student',
+  TEACHER = 'teacher',
+  ADMIN = 'admin',
+}

--- a/backend/src/migrations/1748816397993-create-user-table.ts
+++ b/backend/src/migrations/1748816397993-create-user-table.ts
@@ -3,6 +3,14 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class CreateUserTable1748816397993 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
+      CREATE TYPE user_type_enum AS ENUM (
+        'student',
+        'teacher',
+        'admin'
+      );
+    `);
+    
+    await queryRunner.query(`
       CREATE TABLE public.user (
         user_id VARCHAR(36) NOT NULL,
         
@@ -21,5 +29,6 @@ export class CreateUserTable1748816397993 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DROP TABLE public.user;');
+    await queryRunner.query('DROP TYPE user_type_enum;');
   }
 }

--- a/backend/src/migrations/1748816397993-create-user-table.ts
+++ b/backend/src/migrations/1748816397993-create-user-table.ts
@@ -9,6 +9,7 @@ export class CreateUserTable1748816397993 implements MigrationInterface {
         name VARCHAR(50) NOT NULL,
         email VARCHAR(100) UNIQUE NOT NULL,
         password VARCHAR NOT NULL,
+        type VARCHAR(20) NOT NULL,
 
         created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW() NOT NULL,
         updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW() NOT NULL,

--- a/backend/src/user/dtos/createUser.dto.ts
+++ b/backend/src/user/dtos/createUser.dto.ts
@@ -1,5 +1,6 @@
 import { Matches, IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { UserType } from 'src/Enums/user.enum';
 
 export class CreateUserDto {
   @ApiProperty({ example: 'Maria Silva', description: 'Nome do usuário' })
@@ -20,9 +21,9 @@ export class CreateUserDto {
   @IsString({ message: 'Senha deve ser uma string' })
   password: string;
 
-  @ApiProperty({ example: 'student', description: 'Tipo do usuário (student ou teacher)' })
+  @ApiProperty({ example: 'student', description: 'Tipo do usuário (student ou teacher ou admin)' })
   @IsNotEmpty({ message: 'Tipo é obrigatório' })
-  type: 'student' | 'teacher';
+  type: UserType;
 
   @ApiProperty({ example: '123456', description: 'Matrícula do estudante (opcional)' })
   registrationStudent?: string;

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -1,5 +1,6 @@
 import { Student } from 'src/student/entities/student.entity';
 import { Teacher } from 'src/teacher/entities/teacher.entity';
+import { UserType } from 'src/Enums/user.enum';
 import {
   Entity,
   PrimaryColumn,
@@ -42,6 +43,14 @@ export class User {
     name: 'password',
   })
   password: string;
+
+  @Column({
+    type: 'enum',
+    enum: UserType,
+    nullable: false,
+    name: 'type',
+  })
+  type: UserType;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -24,7 +24,7 @@ export class UserService {
 
   async create(createUserDto: CreateUserDto) {
     // Verifica o tipo de usuário
-    if (createUserDto.type !== 'student' && createUserDto.type !== 'teacher') {
+    if (createUserDto.type !== 'student' && createUserDto.type !== 'teacher' && createUserDto.type !== 'admin') {
       throw new BadRequestException('Tipo de usuário inválido');
     }
 
@@ -93,6 +93,7 @@ export class UserService {
       name: createUserDto.name.trim(),
       email,
       password: hashedPassword,
+      type: createUserDto.type,
     });
 
     await this.userRepository.save(user);


### PR DESCRIPTION
- O Enum utilizado foi exportado para de fato a pasta Enums, administrador (admin) foi incluido.
- Foi criado uma coluna para type na entity user.
- A migration create-user foi modificada e agora possui a coluna type, que tolera todos os três tipos.
- Um teste foi feito, 'admin' passou, assim com 'student' e 'teacher'. Os demais continuam sendo ignorados.